### PR TITLE
Fix sprout init when.js error

### DIFF
--- a/lib/api/init.coffee
+++ b/lib/api/init.coffee
@@ -98,9 +98,12 @@ class Init extends Base
         @questions[i].default = val
 
   prompt_user_for_answers = ->
-    if not @questions.length then return W.resolve()
-    nodecb.call(inquirer.prompt, @questions)
-      .then((o) => @answers = o)
+    d = W.defer()
+    if not @questions.length then d.resolve()
+    inquirer.prompt @questions, (o) =>
+      @answers = o
+      d.resolve()
+    return d.promise
 
   merge_config_values_with_overrides = ->
     @config_values = _.assign(@answers, @overrides)


### PR DESCRIPTION
Hey, I'm just opening this PR to have this documented before I delete the branch. There was an issue with when.js that caused an error when running `sprout init` from the CLI. It involved a regression in when's API with the `callbacks.call` function. The promise was being resolved even though inquirer's `prompt` function hadn't resolved the callback yet. Thankfully @briancavalier was able to help with a [patch](https://github.com/cujojs/when/pull/406) to when.js.
