### PR TITLE
Fix incorrect default if no name given through cli

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -93,7 +93,7 @@ class CLI
       help: 'Name of the template you want to use'
     s.addArgument ['path'],
       nargs: '?'
-      defaultValue: process.cwd()
+      defaultValue: null
       help: 'Path where you want to create your project'
     s.addArgument ['--overrides', '-o'],
       nargs: '*'

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -346,6 +346,20 @@ describe 'cli', ->
         .then(cli.run.bind(cli, 'rm foobar'))
         .should.be.fulfilled
 
+    it 'should default the path to the name of the template in cwd if no path is provided', ->
+      name = 'manatoge'
+      test_path = path.join(process.cwd(), name)
+
+      cli.run("add #{name} #{test_template_url}")
+        .then(cli.run.bind(cli, "init #{name} -o foo bar"))
+        .then ->
+          fs.existsSync(path.join(test_path, 'index.html')).should.be.ok
+          contents = fs.readFileSync(path.join(test_path, 'index.html'), 'utf8')
+          contents.should.match /bar/
+          rimraf.sync(test_path)
+        .then(cli.run.bind(cli, "rm #{name}"))
+        .should.be.fulfilled
+
     # these tests require a better way of responding to the command-line
     # prompts. they will remain stubbed for ref until a new solution is found
     it 'creates a project with multiple inquirer inputs'


### PR DESCRIPTION
This fixes the default behavior when a user does not provide a `path` argument through the CLI. The documentation indicates sprout should use the template name joined with the current working directory path. On [this line in init.coffee](https://github.com/carrot/sprout/blob/2809aaed3282a04063d7d6386c03ccb60c5681e6/lib/api/init.coffee#L73), sprout sets `@target` to the path given, and if `@target` is not present it sets the correct value. The only problem is that `ArgParse` has already a default value for `path` [here](https://github.com/carrot/sprout/blob/6845fe9f0e40a4ad92ca1cf8ffae2e4886ea9121/lib/cli.coffee#L96) before the configuration happens. This causes `@target` to already be defined to `process.cwd()` instead of the correct value of `path.join(process.cwd(), @name)`, which causes issues such as #34. Added a test to prevent regression.

Closes #34.
