### PR TITLE
Use carrot/chai-as-promised and carrot/chai-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "devDependencies": {
     "chai": "2.1.x",
-    "chai-as-promised": "4.x",
-    "chai-fs": "0.1.x",
+    "chai-as-promised": "carrot/chai-as-promised",
+    "chai-fs": "carrot/chai-fs",
     "coffeelint": "1.x",
     "coveralls": "2.x",
     "errno": "0.1.x",


### PR DESCRIPTION
npm versions conflict with chai dependency.