### PR TITLE
assorted clean up

### DIFF
--- a/lib/api/add.coffee
+++ b/lib/api/add.coffee
@@ -50,8 +50,7 @@ class Add extends Base
   determine_if_local = ->
     url  = url.parse(@template)
     remote = url.pathname.split('.')[url.pathname.split('.').length-1] == 'git'
-    if not remote
-      @local = true
+    if not remote then @local = true
     W.resolve()
 
   ###*
@@ -76,12 +75,8 @@ class Add extends Base
   check_internet_connection = ->
     if @local then return W.resolve()
 
-    try
-      nodefn.call(dns.resolve, 'google.com')
-      .catch(-> throw new Error('make that you are connected to the internet!'))
-    catch e
-      console.log 'caught'
-      console.log(e)
+    nodefn.call(dns.resolve, 'google.com').catch ->
+      throw new Error('make that you are connected to the internet!')
 
   ###*
    * If a branch was passed via hash (github.com/foo/bar#some-branch), extract
@@ -103,7 +98,7 @@ class Add extends Base
   ###
 
   remove_existing_template = ->
-    if not @no_internet then nodefn.call(rimraf, @path(@name))
+    nodefn.call(rimraf, @path(@name))
 
   ###*
    * Link up the template to the right spot, whether this is locally or through
@@ -114,7 +109,7 @@ class Add extends Base
     cmd = "git clone #{@template} #{@path(@name)}"
     if @local
       cmd = "rm -rf #{@path(@name)} && ln -s #{@template} #{@path(@name)}"
-    if not @no_internet then nodefn.call(exec, cmd)
+    nodefn.call(exec, cmd)
 
   ###*
    * If there was a branch provided, check it out.

--- a/lib/api/add.coffee
+++ b/lib/api/add.coffee
@@ -62,10 +62,13 @@ class Add extends Base
     if not which.sync('git')
       return W.reject(new Error('you need to have git installed'))
 
-    if not fs.existsSync(path.normalize(@template))
+    tgt = path.normalize(@template)
+    if not fs.existsSync(tgt)
       return W.reject(
         new Error("there is no sprout template located at '#{@template}'")
       )
+    else if not fs.existsSync(path.join(tgt, 'root'))
+      return W.reject('template does not contain root directory')
 
   ###*
    * The most legitimate way to find out if someone is connected to the

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "argparse": "1.0.x",
     "coffee-script": "1.9.x",
     "colors": "1.0.x",
-    "ejs": "2.2.x",
+    "ejs": "2.3.x",
     "indx": "0.2.x",
     "inquirer": "0.8.x",
-    "lodash": "3.3.x",
+    "lodash": "3.5.x",
     "mkdirp": "0.5.x",
     "ncp": "2.0.x",
     "osenv": "0.1.x",
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "test": "npm run lint && mocha",
-    "lint": "find lib/ -name '*.coffee' | xargs coffeelint",
+    "lint": "find lib -name '*.coffee' | xargs coffeelint",
     "coverage": "make build; istanbul cover _mocha --report html -- -R spec && open coverage/index.html && make unbuild",
     "coveralls": "make build; istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage; make unbuild"
   },

--- a/test/fixtures/root-remove/init.coffee
+++ b/test/fixtures/root-remove/init.coffee
@@ -1,0 +1,7 @@
+exports.configure = [
+  {
+    type: 'input',
+    name: 'foo',
+    message: 'What is foo?'
+  }
+]

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -20,6 +20,9 @@ before ->
     nodefn.call(exec, "git init", cwd: path.join(fixtures, dir))
   .should.be.fulfilled
 
+after ->
+  rimraf.sync(sprout.path())
+
 describe 'js api', ->
 
   describe 'add', ->
@@ -43,6 +46,15 @@ describe 'js api', ->
         .then -> sprout.remove('foobar')
         .tap -> fs.existsSync(sprout.path('foobar')).should.not.be.ok
         .should.be.fulfilled
+
+    it 'errors when template does not have `root` directory', ->
+      test_template = path.join(_path, 'no-root')
+      sprout.add(name: 'foobar-6', uri: test_template)
+      .catch (err) ->
+        should.exist(err)
+        err.should.match /template does not contain root directory/
+      .then -> sprout.remove('foobar-6')
+      .should.be.fulfilled
 
     it 'replaces existing template on add', ->
       sprout.add(name: 'foobar', uri: test_template_path)
@@ -270,10 +282,11 @@ describe 'js api', ->
         .then -> sprout.remove('foobar-5')
         .should.be.fulfilled
 
-    it 'errors when template does not have `root` directory', ->
-      test_template = path.join(_path, 'no-root')
+    it 'errors when template has `root` directory removed', ->
+      test_template = path.join(_path, 'root-remove')
       sprout.add(name: 'foobar-6', uri: test_template)
-        .then -> sprout.init(name: 'foobar-6', path: test_path)
+        .then -> rimraf.sync(path.join(sprout.path(), 'foobar-6', 'root'))
+        .then -> sprout.init(name: 'foobar-6', path: test_path, overrides: {foo: 'bar'})
         .catch (err) ->
           should.exist(err)
           err.should.match /template does not contain root directory/


### PR DESCRIPTION
- Throws error/halts chain of no connection + remote add.
- updates lodash and ejs deps
- `sprout.add()` now errors when trying to add a template with no `/root` directory
- new test for when the `/root` dir is removed between `add` and `init`