### PR TITLE
bin: create user path if one is necessary

### DIFF
--- a/bin/sprout
+++ b/bin/sprout
@@ -7,6 +7,8 @@ var CLI = require('./../lib/cli')
   , osenv = require('osenv')
   , crypto = require('crypto')
   , path = require('path')
+  , fs = require('fs')
+  , mkdirp = require('mkdirp')
   , chalk = require('chalk');
 
 /*
@@ -113,11 +115,24 @@ var generateFakeUser = function () {
 var args = parser.parseArgs()
 
 /*
+ * Determine Sprout path; create
+ * user path if it's necessary.
+ */
+
+ var sproutPath = process.env.SPROUT_PATH;
+ if (!sproutPath) {
+   sproutPath = userSproutPath();
+   if (!fs.existsSync(sproutPath)) {
+     mkdirp(sproutPath);
+   }
+ }
+
+/*
  * Initialize CLI interface and
  * event handlers.
  */
 
-var cli = new CLI(process.env.SPROUT_PATH ? process.env.SPROUT_PATH : userSproutPath())
+var cli = new CLI(sproutPath)
   , emitter = cli.emitter;
 
 emitter.on('success',

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "underscore.string": "3.0.x",
     "which": "1.0.x",
     "minimatch": "2.0.x",
-    "isbinaryfile": "2.0.x"
+    "isbinaryfile": "2.0.x",
+    "mkdirp": "^0.5.0"
   },
   "devDependencies": {
     "jsdoc": "^3.3.0-beta2",


### PR DESCRIPTION
Previously, the CLI required `~/.config/sprout` (for example) to exist already to use it.  We should merge this in as soon as possible.