### PR TITLE
Install npm dependencies before init is required

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -326,6 +326,23 @@ module.exports = (function () {
       ).then(
         function () {
 
+          /*
+           * Install npm dependencies, if present.
+           * Eventually, this should work with
+           * package managers other than npm.
+           */
+
+          var pkg = path.join(self.path, 'package.json');
+          if (fs.existsSync(pkg)) {
+            self.emitter.emit('msg', 'installing npm dependencies');
+            return exec('npm install', { cwd: self.path });
+          }
+
+        }
+
+      ).then(
+        function () {
+
           /* Anything occuring beyond this point which
            * throws an error should trigger the removal
            * of target directory!
@@ -360,22 +377,6 @@ module.exports = (function () {
               }
 
               return resolve();
-
-            }
-          ).then(
-            function () {
-
-              /*
-               * Install npm dependencies, if present.
-               * Eventually, this should work with
-               * package managers other than npm.
-               */
-
-              var pkg = path.join(self.path, 'package.json');
-              if (fs.existsSync(pkg)) {
-                self.emitter.emit('msg', 'installing npm dependencies');
-                return exec('npm install', { cwd: self.path });
-              }
 
             }
           ).then(


### PR DESCRIPTION
Previously, templates with `require` calls to dependencies in `init.js` or `init.coffee` would throw errors.