### PR TITLE
Add in recursive clone for possible submodules

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -143,7 +143,7 @@ module.exports = (function () {
 
           if (self.isRemote) {
             self.emitter.emit('cmd', 'git clone ' + self.src + ' ' + self.path);
-            return exec('git clone ' + self.src + ' ' + self.path);
+            return exec('git clone --recursive ' + self.src + ' ' + self.path);
           }
 
           return fs.symlinkAsync(self.src, self.path);


### PR DESCRIPTION
A repo may possibly have submodules that it is dependent on, adding `--recursive` flag to handle that case.