### PR TITLE
Error messages & production install

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -44,7 +44,12 @@ class Template {
       generatorsFolderName: Joi.string().default('generators')
     })
 
-    let options = Joi.validate(_options, schema)
+    let options = Joi.validate(_options, schema, {
+      language: {
+        messages: { wrapArrays: false },
+        object: { child: '!![sprout constructor] option {{reason}}' }
+      }
+    })
     if (options.error) { throw options.error }
     options = options.value
 
@@ -88,7 +93,12 @@ class Template {
 
     Joi.assert(target, Joi.string().required().label('target'))
 
-    return node.call(Joi.validate, opts, schema).with(this)
+    return node.call(Joi.validate, opts, schema, {
+      language: {
+        messages: { wrapArrays: false },
+        object: { child: '!![sprout init] option {{reason}}' }
+      }
+    }).with(this)
       .then((res) => { opts = res })
       .then(this.update.bind(this))
       .then(validateTemplate)
@@ -151,7 +161,12 @@ class Template {
       generatorArgs: Joi.array().single().default([])
     })
 
-    return node.call(Joi.validate, args, schema)
+    return node.call(Joi.validate, args, schema, {
+      language: {
+        messages: { wrapArrays: false },
+        object: { child: '!![sprout generator] option {{reason}}' }
+      }
+    })
       .then((res) => { args = res })
       .then(() => {
         if (!fs.existsSync(target)) {
@@ -287,7 +302,12 @@ function loadConfigFile () {
     defaults: Joi.object()
   })
 
-  const result = Joi.validate(require(initPath), schema)
+  const result = Joi.validate(require(initPath), schema, {
+    language: {
+      messages: { wrapArrays: false },
+      object: { child: '!![sprout init.js] option {{reason}}' }
+    }
+  })
   if (result.error) { throw result.error }
 
   this.init = result.value

--- a/lib/template.js
+++ b/lib/template.js
@@ -270,7 +270,7 @@ function createTargetDirectory (target) {
 function installDependenciesIfPresent () {
   if (!fs.existsSync(path.join(this.path, 'package.json'))) { return }
   this.sprout.emit('msg', 'installing npm dependencies')
-  return exec('npm install', { cwd: this.path })
+  return exec('npm install --production', { cwd: this.path })
 }
 
 function loadConfigFile () {

--- a/test/test.js
+++ b/test/test.js
@@ -1513,7 +1513,7 @@ describe('template',
               }
             ).catch(
               function (error) {
-                error.toString().should.eq('ValidationError: child "target" fails because ["target" must be a string]')
+                error.toString().should.eq('ValidationError: [sprout generator] option "target" must be a string')
                 return template.remove(name).then(
                   function () {
                     return rimraf(target, done)
@@ -1578,7 +1578,7 @@ describe('template',
               }
             ).catch(
               function (error) {
-                error.toString().should.eq('ValidationError: child "generator" fails because ["generator" must be a string]')
+                error.toString().should.eq('ValidationError: [sprout generator] option "generator" must be a string')
                 return template.remove(name).then(
                   function () {
                     return rimraf(target, done)


### PR DESCRIPTION
A couple small optimizations:

- Make error messages more clear. We validate options with joi in a few places in this library, so it will help a lot with debugging to have the error message more clear as to where it's coming from.
- Only install production dependencies in new templates, which will speed up template initialize time significantly.