### PR TITLE
More npm i optimizations

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -283,7 +283,10 @@ function createTargetDirectory (target) {
 }
 
 function installDependenciesIfPresent () {
-  if (!fs.existsSync(path.join(this.path, 'package.json'))) { return }
+  const pkgPath = path.join(this.path, 'package.json')
+  if (!fs.existsSync(pkgPath)) { return }
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  if (!pkg.dependencies) { return }
   this.sprout.emit('msg', 'installing npm dependencies')
   return exec('npm install --production', { cwd: this.path })
 }


### PR DESCRIPTION
Even when installing nothing, if you call `npm i`, it takes about 30 seconds. So it's quicker to read the `package.json` and skip the task if there are no `dependencies`.